### PR TITLE
#31 added time to event_date

### DIFF
--- a/gigsterous-api/src/main/java/com/gigsterous/api/model/Event.java
+++ b/gigsterous-api/src/main/java/com/gigsterous/api/model/Event.java
@@ -1,6 +1,7 @@
 package com.gigsterous.api.model;
 
-import java.util.Date;
+
+import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -35,8 +36,8 @@ public class Event {
 	private String venue;
 	
 	@Column(name = "event_date")
-	@JsonFormat(pattern = "YYYY-MM-dd")
-	private Date date;
+	@JsonFormat(pattern = "YYYY-MM-dd HH:mm")
+	private Timestamp date;
 	
 	@ManyToMany(cascade = CascadeType.ALL)
 	@JoinTable(name = "people_events", joinColumns = @JoinColumn(name = "event_id", referencedColumnName = "event_id"), inverseJoinColumns = @JoinColumn(name = "person_id", referencedColumnName = "person_id"))

--- a/gigsterous-api/src/main/resources/db/development/V1_1__Test_Data.sql
+++ b/gigsterous-api/src/main/resources/db/development/V1_1__Test_Data.sql
@@ -34,8 +34,8 @@ INSERT INTO skills (person_id, instrument, level) VALUES
 	('6', 'BASS', 'ADVANCED');
 	
 INSERT INTO events (event_id, venue, event_date) VALUES 
-	('1', 'Vagon', '2016-12-01'),
-	('2', 'Rudolfinum', '2016-12-24');
+	('1', 'Vagon', '2016-12-01 20:00:00'),
+	('2', 'Rudolfinum', '2016-12-24 19:00:00');
 	
 INSERT INTO people_events (person_id, event_id) VALUES 
 	('1', '1'),


### PR DESCRIPTION
Added time to event_date. Currently using timestamp. It might be beneficial to investigate how to make it work with LocalDateTime in the future.

`yyyy-MM-dd hh:mm:ss` is the default timestamp format for most SQL based databases and it makes more sense to use it rather than UNIX timestamp (the engine itself handles the storage in some universally understood format).
