### PR TITLE
#61 changed username to email address in auth server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are several profiles in the application which can be switched using SPRING
 The whole application is secured with OAuth2. Authorization server needs to be running and contacted for the access token:
 
 ```
-curl -X POST --user 'gigsterous:secret' -d 'grant_type=password&username=peter&password=password' http://localhost:9000/gigsterous-auth/oauth/token
+curl -X POST --user 'gigsterous:secret' -d 'grant_type=password&username=peter@hotmail.com&password=password' http://localhost:9000/gigsterous-auth/oauth/token
 ```
 
 Each request to the API must contain the following header:

--- a/gigsterous-api/src/main/java/com/gigsterous/api/controller/UserController.java
+++ b/gigsterous-api/src/main/java/com/gigsterous/api/controller/UserController.java
@@ -2,15 +2,29 @@ package com.gigsterous.api.controller;
 
 import java.security.Principal;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.gigsterous.api.model.Person;
+import com.gigsterous.api.repository.PersonRepository;
 
 @RestController
 public class UserController {
 	
+	@Autowired
+	private PersonRepository personRepo;
+	
+	/**
+	 * Returns currently logged user as Person object.
+	 * 
+	 * @param user
+	 * @return currently logged user
+	 */
 	@RequestMapping("/user")
-	public Principal user(Principal user) {
-		return user;
+	public Person user(Principal user) {
+		// username in auth server is always email
+		return personRepo.findByEmail(user.getName());
 	}
 
 }

--- a/gigsterous-api/src/main/java/com/gigsterous/api/repository/PersonRepository.java
+++ b/gigsterous-api/src/main/java/com/gigsterous/api/repository/PersonRepository.java
@@ -11,5 +11,6 @@ import com.gigsterous.api.model.Person;
 public interface PersonRepository extends PagingAndSortingRepository<Person, Long> {
 	
 	public Page<Person> findAll(Pageable pageable);
+	public Person findByEmail(String email);
 
 }

--- a/gigsterous-api/src/test/java/com/gigsterous/api/controller/UserControllerTest.java
+++ b/gigsterous-api/src/test/java/com/gigsterous/api/controller/UserControllerTest.java
@@ -4,9 +4,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.gigsterous.api.repository.PersonRepository;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,8 +21,11 @@ public class UserControllerTest {
 	@Autowired
 	private MockMvc mvc;
 	
+	@MockBean
+	private PersonRepository personRepo;
+	
 	@Test
-	@WithMockUser(username = "test", password = "test")
+	@WithMockUser(username = "john@email.cz", password = "password")
 	public void authorizedUserTest() throws Exception {
 	    this.mvc.perform(get("/user")).andExpect(status().isOk());
 	}

--- a/gigsterous-api/src/test/java/com/gigsterous/api/repository/PersonRepositoryTest.java
+++ b/gigsterous-api/src/test/java/com/gigsterous/api/repository/PersonRepositoryTest.java
@@ -18,11 +18,19 @@ public class PersonRepositoryTest {
     private PersonRepository repository;
 
     @Test
-    public void retrievesPerson() {   	
+    public void retrievesPersonById() {   	
         Person result = repository.findOne(1l);
         
         assertEquals("Peter", result.getFirstName());
         assertEquals("Smith", result.getLastName());
+    }
+    
+    @Test
+    public void retrievesPersonByEmail() {   	
+        Person result = repository.findByEmail("john@email.cz");
+        
+        assertEquals("John", result.getFirstName());
+        assertEquals("Doe", result.getLastName());
     }
 
 }

--- a/gigsterous-auth/src/main/java/com/gigsterous/auth/model/User.java
+++ b/gigsterous-auth/src/main/java/com/gigsterous/auth/model/User.java
@@ -30,9 +30,7 @@ public class User implements UserDetails {
 	@Column(name = "user_id", nullable = false, updatable = false)
 	private Long id;
 	
-	@Column(name = "email", nullable = false, unique = true)
-	private String email;
-	
+	// username must be email
 	@Column(name = "username", nullable = false, unique = true)
 	private String username;
 	
@@ -41,10 +39,6 @@ public class User implements UserDetails {
 	
 	@Column(name = "enabled", nullable = false)
 	private boolean enabled;
-	
-	protected User() {
-		// hibernate
-	}
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/gigsterous-auth/src/main/resources/db/development/V1_1__Test_Data.sql
+++ b/gigsterous-auth/src/main/resources/db/development/V1_1__Test_Data.sql
@@ -1,3 +1,3 @@
-INSERT INTO users (user_id, email, username, password, enabled) VALUES 
-	('1', 'peter@hotmail.com', 'peter', '$2a$10$D4OLKI6yy68crm.3imC9X.P2xqKHs5TloWUcr6z5XdOqnTrAK84ri', true),
-	('2', 'john@email.cz', 'john', '$2a$10$D4OLKI6yy68crm.3imC9X.P2xqKHs5TloWUcr6z5XdOqnTrAK84ri', true);
+INSERT INTO users (user_id, username, password, enabled) VALUES 
+	('1', 'peter@hotmail.com', '$2a$10$D4OLKI6yy68crm.3imC9X.P2xqKHs5TloWUcr6z5XdOqnTrAK84ri', true),
+	('2', 'john@email.cz', '$2a$10$D4OLKI6yy68crm.3imC9X.P2xqKHs5TloWUcr6z5XdOqnTrAK84ri', true);

--- a/gigsterous-auth/src/main/resources/db/migration/V1__init.sql
+++ b/gigsterous-auth/src/main/resources/db/migration/V1__init.sql
@@ -2,8 +2,7 @@
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
     user_id BIGINT PRIMARY KEY auto_increment,
-    email VARCHAR(128) UNIQUE,
-    username VARCHAR(32) UNIQUE,
+    username VARCHAR(128) UNIQUE,
     password VARCHAR(256),
     enabled BOOL,
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Usernames are stored as emails in auth server. Validation will have to be performed during registration. Api can now load users by email so it is easy to find currently logged user using his mail in controllers through Principal.
